### PR TITLE
Removing abortion because it exits with not 0 program code when simulation finished correctly

### DIFF
--- a/diff_res_bpsim.py
+++ b/diff_res_bpsim.py
@@ -33,7 +33,6 @@ def cli():
 def start_simulation(ctx, bpmn_path, json_path, total_cases, stat_out_path=None, log_out_path=None, starting_at=None):
     if not run_simulation(bpmn_path, json_path, total_cases, stat_out_path, log_out_path, starting_at):
         print('Simulation model NOT found.')
-        ctx.abort()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As I don't change anything outside of CLI, I'm removing this abortion in case of successful simulation, because otherwise the program returns non-zero exit code, and everything fails.