### PR TITLE
#44 - Case attributes: setup and simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,120 +69,177 @@ Note that the order of the sections is not relevant, i.e., they can appear in an
 * "resource_calendars": List of time intervals in which a resource is available to perform a task on a weekly calendar basis. 
    Each calendar interval is described starting from weekday (Monday, ..., Sunday) at some beginTime, 
    until another (not necessarily different) weekday to some endTime.
+* "case_attributes": Description on which case attributes should be generated during the simulation and what value it should have. There is a possibility to introduce two types of case attributes: `discrete` and `continuous`. The `values` property of the `continuous` case attribute is defined as a distribution function selected from the Python library [Scipy Stats](https://docs.scipy.org/doc/scipy/reference/stats.html#module-scipy.stats). The `values` property of the `discrete` case attribute is defined as an array of possible choices with theirs probability accordingly. The sum of probabilities should be equal to 1. 
 
 The following snippet outlines an example of the general structure of the input JSON parameters with the simulation parameters.
 
-      {
-          "resource_profiles": [
-              {
-                  "id": "Profile ID_1",
-                  "name": "Credit Officer",
-                  "resource_list": [
-                      {
-                          "id": "resource_id_1",
-                          "name": "Credit Officer_1",
-                          "cost_per_hour": "35",
-                          "amount": 1,
-                          "calendar": "sid-222A1118-4766-43B2-A004-7DADE521982D",
-                          "assignedTasks": ["sid-622A1118-4766-43B2-A004-7DADE521982D"]
-                      },
-                      {
-                          "id": "resource_id_2",
-                          "name": "Credit Officer_2",
-                          "cost_per_hour": "35",
-                          "amount": 1,
-                          "calendar": "sid-222A1118-4766-43B2-A004-7DADE521982D",
-                          "assignedTasks": ["sid-622A1118-4766-43B2-A004-7DADE521982D"]
-                      }
-                  ]
-              }
-          ],
-          "arrival_time_distribution": {
-              "distribution_name": "expon",
-              "distribution_params": [
-                  { "value": 0 },
-                  { "value": 1800.0 },
-                  { "value": 90.0 }
-              ]
-          },
-          "arrival_time_calendar": [{
-              "from": "MONDAY",
-              "to": "FRIDAY",
-              "beginTime": "09:00:00.000",
-              "endTime": "17:00:00.000"
-          }],
-          "gateway_branching_probabilities": [
-              {
-                  "gateway_id": "sid-64FC5B46-47E5-4940-A0AF-ECE87483967D",
-                  "probabilities": [
-                      {
-                          "path_id": "sid-8AE82A7B-75EE-401B-8ABE-279FB05A3946",
-                          "value": "0.7"
-                      },
-                      {
-                          "path_id": "sid-789335C6-205C-4A03-9AD6-9655893C1FFB",
-                          "value": "0.3"
-                      }
-                  ]
-              },
-              {
-                  "gateway_id": "sid-FACFF0AE-6A1B-47AC-B289-F5E60CB12B2A",
-                  "probabilities": [
-                      {
-                          "path_id": "sid-AFEC7074-8C12-43E2-A1FE-87D5CEF395C8",
-                          "value": "0.3"
-                      },
-                      {
-                          "path_id": "sid-AE313010-5715-438C-AD61-1C02F03DCF77",
-                          "value": "0.7"
-                      }
-                  ]
-              }
-          ],
-          "task_resource_distribution": [
-              {
-                  "task_id": "sid-622A1118-4766-43B2-A004-7DADE521982D",
-                  "resources": [
-                      {
-                          "resource_id": "resource_id_1",
-                          "distribution_name": "norm",
-                          "distribution_params": [
-                              { "value": 600.0 },
-                              { "value": 120.0 }
-                          ]
-                      },
-                      {
-                          "resource_id": "resource_id_2",
-                          "distribution_name": "norm",
-                          "distribution_params": [
-                              { "value": 60.0 },
-                              { "value": 12.0 }
-                          ]             
-                      }
-                  ]
-              }
-          ],
-          "resource_calendars": [
-              {
-                  "id": "sid-222A1118-4766-43B2-A004-7DADE521982D",
-                  "name": "calendar1",
-                  "time_periods": [
-                      {
-                          "from": "MONDAY",
-                          "to": "FRIDAY",
-                          "beginTime": "09:00:00.000",
-                          "endTime": "17:00:00.000"
-                      },
-                      {
-                          "from": "SATURDAY",
-                          "to": "SATURDAY",
-                          "beginTime": "09:00:00.000",
-                          "endTime": "13:00:00.000"
-                      }
-                  ]
-              }
-          ]
-      }
+```json
+{
+    "resource_profiles": [
+        {
+            "id": "Profile ID_1",
+            "name": "Credit Officer",
+            "resource_list": [
+                {
+                    "id": "resource_id_1",
+                    "name": "Credit Officer_1",
+                    "cost_per_hour": "35",
+                    "amount": 1,
+                    "calendar": "sid-222A1118-4766-43B2-A004-7DADE521982D",
+                    "assignedTasks": [
+                        "sid-622A1118-4766-43B2-A004-7DADE521982D"
+                    ]
+                },
+                {
+                    "id": "resource_id_2",
+                    "name": "Credit Officer_2",
+                    "cost_per_hour": "35",
+                    "amount": 1,
+                    "calendar": "sid-222A1118-4766-43B2-A004-7DADE521982D",
+                    "assignedTasks": [
+                        "sid-622A1118-4766-43B2-A004-7DADE521982D"
+                    ]
+                }
+            ]
+        }
+    ],
+    "arrival_time_distribution": {
+        "distribution_name": "expon",
+        "distribution_params": [
+            {
+                "value": 0
+            },
+            {
+                "value": 1800.0
+            },
+            {
+                "value": 90.0
+            }
+        ]
+    },
+    "arrival_time_calendar": [
+        {
+            "from": "MONDAY",
+            "to": "FRIDAY",
+            "beginTime": "09:00:00.000",
+            "endTime": "17:00:00.000"
+        }
+    ],
+    "gateway_branching_probabilities": [
+        {
+            "gateway_id": "sid-64FC5B46-47E5-4940-A0AF-ECE87483967D",
+            "probabilities": [
+                {
+                    "path_id": "sid-8AE82A7B-75EE-401B-8ABE-279FB05A3946",
+                    "value": "0.7"
+                },
+                {
+                    "path_id": "sid-789335C6-205C-4A03-9AD6-9655893C1FFB",
+                    "value": "0.3"
+                }
+            ]
+        },
+        {
+            "gateway_id": "sid-FACFF0AE-6A1B-47AC-B289-F5E60CB12B2A",
+            "probabilities": [
+                {
+                    "path_id": "sid-AFEC7074-8C12-43E2-A1FE-87D5CEF395C8",
+                    "value": "0.3"
+                },
+                {
+                    "path_id": "sid-AE313010-5715-438C-AD61-1C02F03DCF77",
+                    "value": "0.7"
+                }
+            ]
+        }
+    ],
+    "task_resource_distribution": [
+        {
+            "task_id": "sid-622A1118-4766-43B2-A004-7DADE521982D",
+            "resources": [
+                {
+                    "resource_id": "resource_id_1",
+                    "distribution_name": "norm",
+                    "distribution_params": [
+                        {
+                            "value": 600.0
+                        },
+                        {
+                            "value": 120.0
+                        }
+                    ]
+                },
+                {
+                    "resource_id": "resource_id_2",
+                    "distribution_name": "norm",
+                    "distribution_params": [
+                        {
+                            "value": 60.0
+                        },
+                        {
+                            "value": 12.0
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "resource_calendars": [
+        {
+            "id": "sid-222A1118-4766-43B2-A004-7DADE521982D",
+            "name": "calendar1",
+            "time_periods": [
+                {
+                    "from": "MONDAY",
+                    "to": "FRIDAY",
+                    "beginTime": "09:00:00.000",
+                    "endTime": "17:00:00.000"
+                },
+                {
+                    "from": "SATURDAY",
+                    "to": "SATURDAY",
+                    "beginTime": "09:00:00.000",
+                    "endTime": "13:00:00.000"
+                }
+            ]
+        }
+    ],
+    "case_attributes": [
+        {
+            "name": "client_type",
+            "type": "discrete",
+            "values": [
+                {
+                    "key": "REGULAR",
+                    "value": 0.8
+                },
+                {
+                    "key": "BUSINESS",
+                    "value": 0.2
+                }
+            ]
+        },
+        {
+            "name": "loan_amount",
+            "type": "continuous",
+            "values": {
+                "distribution_name": "fix",
+                "distribution_params": [
+                    {
+                        "value": 240
+                    },
+                    {
+                        "value": 0
+                    },
+                    {
+                        "value": 1
+                    }
+                ]
+            }
+        }
+    ]
+}
+```
 
 ## Running Experiments BPM-2022
 

--- a/bpdfr_discovery/log_parser.py
+++ b/bpdfr_discovery/log_parser.py
@@ -14,12 +14,12 @@ from bpdfr_simulation_engine.control_flow_manager import BPMN, BPMNGraph
 from bpdfr_simulation_engine.exceptions import InvalidBpmnModelException, InvalidLogFileException
 
 from bpdfr_simulation_engine.execution_info import ProcessInfo, Trace, TaskEvent
+from bpdfr_simulation_engine.file_manager import FileManager
 from bpdfr_simulation_engine.probability_distributions import best_fit_distribution
 
 import ntpath
 
 from bpdfr_simulation_engine.resource_calendar import RCalendar, CalendarFactory
-from bpdfr_simulation_engine.simulation_engine import add_simulation_event_log_header
 from bpdfr_simulation_engine.simulation_properties_parser import parse_simulation_model
 
 print_info = False
@@ -50,7 +50,7 @@ def transform_xes_to_csv(log_path, csv_out_path):
 
     with open(csv_out_path, mode='w', newline='', encoding='utf-8') as log_csv_file:
         csv_writer = csv.writer(log_csv_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
-        add_simulation_event_log_header(csv_writer)
+        log_writer = FileManager(10000, csv_writer)
         log_traces = xes_importer.apply(log_path)
         for trace in log_traces:
             started_events = dict()
@@ -70,8 +70,10 @@ def transform_xes_to_csv(log_path, csv_out_path):
                 elif state == "complete":
                     if task_name in started_events:
                         c_event = trace_info.complete_event(started_events.pop(task_name), timestamp)
-                        csv_writer.writerow([trace_info.p_case, task_name, '', str(c_event.started_at),
+                        log_writer.add_csv_row([trace_info.p_case, task_name, '', str(c_event.started_at),
                                              str(c_event.completed_at), resource])
+
+        log_writer.force_write()
 
 
 def is_duplicated(visited_events, p_case, task_name, resource, timestamp, state):

--- a/bpdfr_simulation_engine/case_attributes.py
+++ b/bpdfr_simulation_engine/case_attributes.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import List
 from bpdfr_simulation_engine.probability_distributions import generate_number_from
 from random import choices
 
@@ -29,14 +30,6 @@ def parse_continuous_value(value_info):
     }
 
 
-class AllCaseAttributes():
-    def __init__(self, case_attr_arr):
-        self.attributes = case_attr_arr
-
-    def get_columns_generated(self):
-        return map(lambda i: i.name, self.attributes)
-
-
 class CaseAttribute():
     def __init__(self, name, case_atrr_type, value):
         self.name: str = name
@@ -51,6 +44,21 @@ class CaseAttribute():
 
     def get_next_value(self):
         if self.case_atrr_type == CASE_ATTR_TYPE.DISCRETE:
-            return choices(self.value["options"], self.value["probabilities"])
+            one_choice_arr = choices(self.value["options"], self.value["probabilities"])
+            return one_choice_arr[0]
         else:
             return generate_number_from(self.value["distribution_name"], self.value["distribution_params"])
+
+
+class AllCaseAttributes():
+    def __init__(self, case_attr_arr: List[CaseAttribute]):
+        self.attributes = case_attr_arr
+
+    def get_columns_generated(self):
+        return [attr.name for attr in self.attributes]
+
+    def get_values_calculated(self):
+        # return the list of calculated values specified
+        # the order should reflect the one with headers
+
+        return [attr.get_next_value() for attr in self.attributes]

--- a/bpdfr_simulation_engine/case_attributes.py
+++ b/bpdfr_simulation_engine/case_attributes.py
@@ -1,5 +1,7 @@
 from enum import Enum
+from functools import reduce
 from typing import List
+from bpdfr_simulation_engine.exceptions import InvalidCaseAttributeException
 from bpdfr_simulation_engine.probability_distributions import generate_number_from
 from random import choices
 
@@ -42,12 +44,23 @@ class CaseAttribute():
         else:
             raise Exception(f"Not supported case attribute {type}")
 
+        self.validate()
+
     def get_next_value(self):
         if self.case_atrr_type == CASE_ATTR_TYPE.DISCRETE:
             one_choice_arr = choices(self.value["options"], self.value["probabilities"])
             return one_choice_arr[0]
         else:
             return generate_number_from(self.value["distribution_name"], self.value["distribution_params"])
+
+    def validate(self):
+        if self.case_atrr_type == CASE_ATTR_TYPE.DISCRETE:
+            actual_sum_probabilities = reduce(lambda acc, item: acc + item, self.value["probabilities"], 0) 
+            
+            if actual_sum_probabilities != 1:
+                raise InvalidCaseAttributeException(f"Case attribute ${self.name}: probabilities' sum should be equal to 1") 
+        
+        return True
 
 
 class AllCaseAttributes():

--- a/bpdfr_simulation_engine/case_attributes.py
+++ b/bpdfr_simulation_engine/case_attributes.py
@@ -28,6 +28,15 @@ def parse_continuous_value(value_info):
         "distribution_params": dist_params
     }
 
+
+class AllCaseAttributes():
+    def __init__(self, case_attr_arr):
+        self.attributes = case_attr_arr
+
+    def get_columns_generated(self):
+        return map(lambda i: i.name, self.attributes)
+
+
 class CaseAttribute():
     def __init__(self, name, case_atrr_type, value):
         self.name: str = name
@@ -40,7 +49,7 @@ class CaseAttribute():
         else:
             raise Exception(f"Not supported case attribute {type}")
 
-    def _get_next_value(self):
+    def get_next_value(self):
         if self.case_atrr_type == CASE_ATTR_TYPE.DISCRETE:
             return choices(self.value["options"], self.value["probabilities"])
         else:

--- a/bpdfr_simulation_engine/case_attributes.py
+++ b/bpdfr_simulation_engine/case_attributes.py
@@ -1,0 +1,47 @@
+from enum import Enum
+from bpdfr_simulation_engine.probability_distributions import generate_number_from
+from random import choices
+
+class CASE_ATTR_TYPE(Enum):
+    DISCRETE = "discrete"
+    CONTINUOUS = "continuous"
+
+def parse_discrete_value(value_info_arr):
+    prob_arr = []
+    options_arr = []
+    for item in value_info_arr:
+        options_arr.append(item["key"])
+        prob_arr.append(float(item["value"]))
+
+    return {
+        "options": options_arr,
+        "probabilities": prob_arr
+    }
+
+def parse_continuous_value(value_info):
+    dist_params = []
+    for param_info in value_info["distribution_params"]:
+        dist_params.append(float(param_info["value"]))
+    
+    return {
+        "distribution_name": value_info["distribution_name"],
+        "distribution_params": dist_params
+    }
+
+class CaseAttribute():
+    def __init__(self, name, case_atrr_type, value):
+        self.name: str = name
+        self.case_atrr_type: CASE_ATTR_TYPE = CASE_ATTR_TYPE(case_atrr_type)
+
+        if self.case_atrr_type == CASE_ATTR_TYPE.DISCRETE:
+            self.value = parse_discrete_value(value)
+        elif self.case_atrr_type == CASE_ATTR_TYPE.CONTINUOUS:
+            self.value = parse_continuous_value(value)
+        else:
+            raise Exception(f"Not supported case attribute {type}")
+
+    def _get_next_value(self):
+        if self.case_atrr_type == CASE_ATTR_TYPE.DISCRETE:
+            return choices(self.value["options"], self.value["probabilities"])
+        else:
+            return generate_number_from(self.value["distribution_name"], self.value["distribution_params"])

--- a/bpdfr_simulation_engine/exceptions.py
+++ b/bpdfr_simulation_engine/exceptions.py
@@ -14,3 +14,6 @@ class InvalidLogFileException(Error):
 
 class InvalidRuleDefinition(Error):
     """Raised when the defined rule is invalid"""
+
+class InvalidCaseAttributeException(Error):
+    """Raised when the defined case attribute is invalid"""

--- a/bpdfr_simulation_engine/file_manager.py
+++ b/bpdfr_simulation_engine/file_manager.py
@@ -1,15 +1,27 @@
 
 class FileManager:
-    def __init__(self, chunk_size, file_writter):
+    # class is used only for saving the log file in csv
+    def __init__(self, chunk_size, file_writter, additional_column_names = []):
         self.chunk_size = chunk_size
         self.data_buffer = list()
         self.file_writter = file_writter
+
+        self._add_header_row(additional_column_names)
 
     def add_csv_row(self, csv_row):
         if self.file_writter:
             self.data_buffer.append(csv_row)
             if len(self.data_buffer) >= self.chunk_size:
                 self.force_write()
+
+    def _add_header_row(self, additional_column_names = []):
+        # additional_column_names is present only in case 
+        # there is a provided setup for additional case attributes
+
+        if self.file_writter:
+            header_row = ['case_id', 'activity', 'enable_time', 'start_time', 'end_time', 'resource']
+            header_row.extend(additional_column_names)
+            self.file_writter.writerow(header_row)
 
     def force_write(self):
         if self.file_writter:

--- a/bpdfr_simulation_engine/simulation_engine.py
+++ b/bpdfr_simulation_engine/simulation_engine.py
@@ -152,7 +152,7 @@ class SimBPMEnv:
         
         # TODO: make sure to test the case without the resource (events)
         resource_name = self.sim_setup.resources_map[full_event.resource_id].resource_name \
-            if (type(full_event.resource_id) == str) else \
+            if (hasattr(full_event, "resource_id")) else \
                 "No assigned resource"
         
         row_basic_info = verify_miliseconds([full_event.p_case,
@@ -284,7 +284,7 @@ class SimBPMEnv:
 
                 self.sim_resources[r_id].worked_time += full_evt.ideal_duration
                 completed_at, completed_datetime = self._update_logs_and_resource_availability(
-                    full_evt, p_case, task_id, r_id
+                    full_evt, r_id
                 )
 
                 yield completed_at, completed_datetime, p_case
@@ -326,7 +326,7 @@ class SimBPMEnv:
                                     enabled_datetime, self, num_tasks_in_batch)
 
                 completed_at, completed_datetime = self._update_logs_and_resource_availability(
-                    full_evt, p_case, task_id, r_id
+                    full_evt, r_id
                 )
 
                 yield completed_at, completed_datetime, p_case

--- a/bpdfr_simulation_engine/simulation_engine.py
+++ b/bpdfr_simulation_engine/simulation_engine.py
@@ -150,7 +150,6 @@ class SimBPMEnv:
         In case we have defined case attributes setup, we will have additional columns besides the basic ones.
         """
         
-        # TODO: make sure to test the case without the resource (events)
         resource_name = self.sim_setup.resources_map[full_event.resource_id].resource_name \
             if (hasattr(full_event, "resource_id")) else \
                 "No assigned resource"

--- a/bpdfr_simulation_engine/simulation_engine.py
+++ b/bpdfr_simulation_engine/simulation_engine.py
@@ -6,7 +6,7 @@ from typing import List
 import pytz
 import datetime
 from datetime import timedelta
-from bpdfr_simulation_engine.control_flow_manager import BPMN, EVENT_TYPE, CustomDatetimeAndSeconds, EnabledTask
+from bpdfr_simulation_engine.control_flow_manager import BPMN, CustomDatetimeAndSeconds
 
 from bpdfr_simulation_engine.file_manager import FileManager
 from bpdfr_simulation_engine.execution_info import Trace, TaskEvent, EnabledEvent
@@ -31,7 +31,7 @@ class SimBPMEnv:
         self.sim_setup = sim_setup
         self.sim_resources = dict()
         self.stat_fwriter = stat_fwriter
-        self.log_writer = FileManager(10000, log_fwriter)
+        self.log_writer = FileManager(10000, log_fwriter, self.sim_setup.case_attributes.get_columns_generated())
         self.log_info = LogInfo(sim_setup)
         self.executed_events = 0
         self.time_update_process_state = 0
@@ -455,7 +455,6 @@ def run_simulation(bpmn_path, json_path, total_cases, stat_out_path=None, log_ou
 
 def run_simpy_simulation(diffsim_info, total_cases, stat_fwriter, log_fwriter):
     bpm_env = SimBPMEnv(diffsim_info, stat_fwriter, log_fwriter)
-    add_simulation_event_log_header(log_fwriter)
     execute_full_process(bpm_env, total_cases)
     if log_fwriter is None and stat_fwriter is None:
         return bpm_env.log_info.compute_process_kpi(bpm_env), bpm_env.log_info
@@ -465,11 +464,6 @@ def run_simpy_simulation(diffsim_info, total_cases, stat_fwriter, log_fwriter):
         bpm_env.log_info.save_joint_statistics(bpm_env)
     return None
 
-
-def add_simulation_event_log_header(log_fwriter):
-    if log_fwriter:
-        log_fwriter.writerow([
-            'case_id', 'activity', 'enable_time', 'start_time', 'end_time', 'resource', ])
 
 def verify_miliseconds(array):
     """

--- a/bpdfr_simulation_engine/simulation_properties_parser.py
+++ b/bpdfr_simulation_engine/simulation_properties_parser.py
@@ -5,7 +5,7 @@ import xml.etree.ElementTree as ET
 
 from numpy import exp, sqrt, log
 from bpdfr_simulation_engine.batch_processing import BATCH_TYPE, RULE_TYPE, BatchConfigPerTask, AndFiringRule, FiringSubRule, OrFiringRule
-from bpdfr_simulation_engine.case_attributes import CaseAttribute
+from bpdfr_simulation_engine.case_attributes import AllCaseAttributes, CaseAttribute
 
 from bpdfr_simulation_engine.control_flow_manager import EVENT_TYPE, BPMNGraph, ElementInfo, BPMN
 from bpdfr_simulation_engine.exceptions import InvalidRuleDefinition
@@ -32,13 +32,11 @@ def parse_json_sim_parameters(json_path):
         event_distibution = parse_event_distribution(json_data["event_distribution"]) \
             if "event_distribution" in json_data else dict()
         batch_processing = parse_batch_processing(json_data["batch_processing"])
-        case_attr = parse_case_attr(json_data["case_attributes"]) \
-            if "case_attributes" in json_data else dict()
+        case_attributes = parse_case_attr(json_data["case_attributes"]) \
+            if "case_attributes" in json_data else AllCaseAttributes([])
 
-        val = case_attr[0]._get_next_value()
-        print(val)
-
-        return resources_map, calendars_map, element_distribution, task_resource_distribution, arrival_calendar, event_distibution, batch_processing
+        return resources_map, calendars_map, element_distribution, task_resource_distribution, \
+            arrival_calendar, event_distibution, batch_processing, case_attributes
 
 
 # def parse_pool_info(json_data, resources_map):
@@ -190,13 +188,13 @@ def parse_size_distrib(size_distrib):
     return possible_options, probabilities
 
 
-def parse_case_attr(json_data) -> List[CaseAttribute]:
+def parse_case_attr(json_data) -> AllCaseAttributes:
     case_attributes = []
     for curr_case_attr in json_data:
         case_attr = CaseAttribute(curr_case_attr["name"], curr_case_attr["type"], curr_case_attr["values"])
         case_attributes.append(case_attr)
 
-    return case_attributes
+    return AllCaseAttributes(case_attributes)
 
 
 def create_subrule(attribute, comparison, value):

--- a/bpdfr_simulation_engine/simulation_properties_parser.py
+++ b/bpdfr_simulation_engine/simulation_properties_parser.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ET
 
 from numpy import exp, sqrt, log
 from bpdfr_simulation_engine.batch_processing import BATCH_TYPE, RULE_TYPE, BatchConfigPerTask, AndFiringRule, FiringSubRule, OrFiringRule
+from bpdfr_simulation_engine.case_attributes import CaseAttribute
 
 from bpdfr_simulation_engine.control_flow_manager import EVENT_TYPE, BPMNGraph, ElementInfo, BPMN
 from bpdfr_simulation_engine.exceptions import InvalidRuleDefinition
@@ -31,7 +32,11 @@ def parse_json_sim_parameters(json_path):
         event_distibution = parse_event_distribution(json_data["event_distribution"]) \
             if "event_distribution" in json_data else dict()
         batch_processing = parse_batch_processing(json_data["batch_processing"])
+        case_attr = parse_case_attr(json_data["case_attributes"]) \
+            if "case_attributes" in json_data else dict()
 
+        val = case_attr[0]._get_next_value()
+        print(val)
 
         return resources_map, calendars_map, element_distribution, task_resource_distribution, arrival_calendar, event_distibution, batch_processing
 
@@ -157,9 +162,7 @@ def parse_batch_processing(batch_processing_json_data):
             value = float(item['value'])
             duration_distibution[key] = value
 
-        # TODO: "batch_frequency" should be added, as well
-        size_distrib = batch_processing["size_distrib"]
-        possible_options, probabilities = parse_size_distrib(size_distrib)
+        possible_options, probabilities = parse_size_distrib(batch_processing["size_distrib"])
 
         batch_config[t_id] = BatchConfigPerTask(
             batch_type,
@@ -185,6 +188,15 @@ def parse_size_distrib(size_distrib):
         probabilities.append(item['value'])
 
     return possible_options, probabilities
+
+
+def parse_case_attr(json_data) -> List[CaseAttribute]:
+    case_attributes = []
+    for curr_case_attr in json_data:
+        case_attr = CaseAttribute(curr_case_attr["name"], curr_case_attr["type"], curr_case_attr["values"])
+        case_attributes.append(case_attr)
+
+    return case_attributes
 
 
 def create_subrule(attribute, comparison, value):

--- a/bpdfr_simulation_engine/simulation_setup.py
+++ b/bpdfr_simulation_engine/simulation_setup.py
@@ -12,7 +12,7 @@ from bpdfr_simulation_engine.simulation_properties_parser import parse_simulatio
 
 
 class SimDiffSetup:
-    def __init__(self, bpmn_path, json_path, is_event_added_to_log):
+    def __init__(self, bpmn_path, json_path, is_event_added_to_log, total_cases):
         self.process_name = ntpath.basename(bpmn_path).split(".")[0]
         self.start_datetime = datetime.datetime.now(pytz.utc)
 
@@ -27,6 +27,7 @@ class SimDiffSetup:
             self.arrival_calendar = self.find_arrival_calendar()
 
         self.is_event_added_to_log = is_event_added_to_log
+        self.total_num_cases = total_cases # how many process cases should be simulated
 
     def verify_simulation_input(self):
         for e_id in self.bpmn_graph.element_info:

--- a/bpdfr_simulation_engine/simulation_setup.py
+++ b/bpdfr_simulation_engine/simulation_setup.py
@@ -17,7 +17,7 @@ class SimDiffSetup:
         self.start_datetime = datetime.datetime.now(pytz.utc)
 
         self.resources_map, self.calendars_map, self.element_probability, self.task_resource, self.arrival_calendar, \
-            self.event_distibution, self.batch_processing \
+            self.event_distibution, self.batch_processing, self.case_attributes \
             = parse_json_sim_parameters(json_path)
 
         self.bpmn_graph = parse_simulation_model(bpmn_path)

--- a/testing_scripts/assets/batch-example-with-batch.json
+++ b/testing_scripts/assets/batch-example-with-batch.json
@@ -1,16 +1,16 @@
 {
-   "resource_profiles":[
+   "resource_profiles": [
       {
-         "id":"sid-generic-resource",
-         "name":"Generic_Resource",
-         "resource_list":[
+         "id": "sid-generic-resource",
+         "name": "Generic_Resource",
+         "resource_list": [
             {
-               "id":"Resource_1",
-               "name":"Resource_1",
-               "cost_per_hour":1,
-               "amount":1,
-               "calendar":"247timetable",
-               "assigned_tasks":[
+               "id": "Resource_1",
+               "name": "Resource_1",
+               "cost_per_hour": 1,
+               "amount": 1,
+               "calendar": "247timetable",
+               "assigned_tasks": [
                   "sid-02577CBF-ABA3-4EFD-9480-E1DFCF238B1C",
                   "sid-4B24111F-B305-4608-9E12-744B47C44D0D",
                   "sid-D048D99D-F549-43B8-8ACB-5AE153B12B0F",
@@ -18,12 +18,12 @@
                ]
             },
             {
-               "id":"Resource_2",
-               "name":"Resource_2",
-               "cost_per_hour":1,
-               "amount":1,
-               "calendar":"247timetable",
-               "assigned_tasks":[
+               "id": "Resource_2",
+               "name": "Resource_2",
+               "cost_per_hour": 1,
+               "amount": 1,
+               "calendar": "247timetable",
+               "assigned_tasks": [
                   "sid-02577CBF-ABA3-4EFD-9480-E1DFCF238B1C",
                   "sid-4B24111F-B305-4608-9E12-744B47C44D0D",
                   "sid-D048D99D-F549-43B8-8ACB-5AE153B12B0F",
@@ -31,12 +31,12 @@
                ]
             },
             {
-               "id":"Resource_3",
-               "name":"Resource_3",
-               "cost_per_hour":1,
-               "amount":1,
-               "calendar":"247timetable",
-               "assigned_tasks":[
+               "id": "Resource_3",
+               "name": "Resource_3",
+               "cost_per_hour": 1,
+               "amount": 1,
+               "calendar": "247timetable",
+               "assigned_tasks": [
                   "sid-02577CBF-ABA3-4EFD-9480-E1DFCF238B1C",
                   "sid-4B24111F-B305-4608-9E12-744B47C44D0D",
                   "sid-D048D99D-F549-43B8-8ACB-5AE153B12B0F",
@@ -44,12 +44,12 @@
                ]
             },
             {
-               "id":"Resource_4",
-               "name":"Resource_4",
-               "cost_per_hour":1,
-               "amount":1,
-               "calendar":"247timetable",
-               "assigned_tasks":[
+               "id": "Resource_4",
+               "name": "Resource_4",
+               "cost_per_hour": 1,
+               "amount": 1,
+               "calendar": "247timetable",
+               "assigned_tasks": [
                   "sid-02577CBF-ABA3-4EFD-9480-E1DFCF238B1C",
                   "sid-4B24111F-B305-4608-9E12-744B47C44D0D",
                   "sid-D048D99D-F549-43B8-8ACB-5AE153B12B0F",
@@ -57,12 +57,12 @@
                ]
             },
             {
-               "id":"Resource_5",
-               "name":"Resource_5",
-               "cost_per_hour":1,
-               "amount":1,
-               "calendar":"247timetable",
-               "assigned_tasks":[
+               "id": "Resource_5",
+               "name": "Resource_5",
+               "cost_per_hour": 1,
+               "amount": 1,
+               "calendar": "247timetable",
+               "assigned_tasks": [
                   "sid-02577CBF-ABA3-4EFD-9480-E1DFCF238B1C",
                   "sid-4B24111F-B305-4608-9E12-744B47C44D0D",
                   "sid-D048D99D-F549-43B8-8ACB-5AE153B12B0F",
@@ -72,481 +72,527 @@
          ]
       }
    ],
-   "arrival_time_distribution":{
-      "distribution_name":"fix",
-      "distribution_params":[
+   "arrival_time_distribution": {
+      "distribution_name": "fix",
+      "distribution_params": [
          {
-            "value":120
+            "value": 120
          },
          {
-            "value":0
+            "value": 0
          },
          {
-            "value":1
+            "value": 1
          }
       ]
    },
-   "arrival_time_calendar":[
+   "arrival_time_calendar": [
       {
-         "from":"MONDAY",
-         "to":"SUNDAY",
-         "beginTime":"00:00:00.000",
-         "endTime":"23:59:59.999"
+         "from": "MONDAY",
+         "to": "SUNDAY",
+         "beginTime": "00:00:00.000",
+         "endTime": "23:59:59.999"
       }
    ],
-   "gateway_branching_probabilities":[
+   "gateway_branching_probabilities": [
       {
-         "gateway_id":"sid-6B518C80-2B96-4C95-B6DE-F9E4A75FF191",
-         "probabilities":[
+         "gateway_id": "sid-6B518C80-2B96-4C95-B6DE-F9E4A75FF191",
+         "probabilities": [
             {
-               "path_id":"sid-6FD4FFD3-5784-4D33-9509-234EAB886930",
-               "value":0.3
+               "path_id": "sid-6FD4FFD3-5784-4D33-9509-234EAB886930",
+               "value": 0.3
             },
             {
-               "path_id":"sid-9E95A790-241E-4629-8D67-E9A2CE55E3DC",
-               "value":0.7
+               "path_id": "sid-9E95A790-241E-4629-8D67-E9A2CE55E3DC",
+               "value": 0.7
             }
          ]
       }
    ],
-   "task_resource_distribution":[
+   "task_resource_distribution": [
       {
-         "task_id":"sid-4B24111F-B305-4608-9E12-744B47C44D0D",
-         "resources":[
+         "task_id": "sid-4B24111F-B305-4608-9E12-744B47C44D0D",
+         "resources": [
             {
-               "resource_id":"Resource_1",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_1",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_2",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_2",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_3",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_3",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_4",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_4",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_5",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_5",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             }
          ]
       },
       {
-         "task_id":"sid-D048D99D-F549-43B8-8ACB-5AE153B12B0F",
-         "resources":[
+         "task_id": "sid-D048D99D-F549-43B8-8ACB-5AE153B12B0F",
+         "resources": [
             {
-               "resource_id":"Resource_1",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_1",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_2",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_2",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_3",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_3",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_4",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_4",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_5",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_5",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             }
          ]
       },
       {
-         "task_id":"sid-02577CBF-ABA3-4EFD-9480-E1DFCF238B1C",
-         "resources":[
+         "task_id": "sid-02577CBF-ABA3-4EFD-9480-E1DFCF238B1C",
+         "resources": [
             {
-               "resource_id":"Resource_1",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_1",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_2",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_2",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_3",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_3",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_4",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_4",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_5",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_5",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             }
          ]
       },
       {
-         "task_id":"sid-503A048D-6344-446A-8D67-172B164CF8FA",
-         "resources":[
+         "task_id": "sid-503A048D-6344-446A-8D67-172B164CF8FA",
+         "resources": [
             {
-               "resource_id":"Resource_1",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_1",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_2",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_2",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_3",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_3",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_4",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_4",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_5",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_5",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             }
          ]
       },
       {
-         "task_id":"Activity_0ngxjs9",
-         "resources":[
+         "task_id": "Activity_0ngxjs9",
+         "resources": [
             {
-               "resource_id":"Resource_1",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_1",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_2",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_2",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_3",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_3",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_4",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_4",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             },
             {
-               "resource_id":"Resource_5",
-               "distribution_name":"fix",
-               "distribution_params":[
+               "resource_id": "Resource_5",
+               "distribution_name": "fix",
+               "distribution_params": [
                   {
-                     "value":120
+                     "value": 120
                   },
                   {
-                     "value":0
+                     "value": 0
                   },
                   {
-                     "value":1
+                     "value": 1
                   }
                ]
             }
          ]
       }
    ],
-   "resource_calendars":[
+   "resource_calendars": [
       {
-         "id":"247timetable",
-         "name":"247timetable",
-         "time_periods":[
+         "id": "247timetable",
+         "name": "247timetable",
+         "time_periods": [
             {
-               "from":"MONDAY",
-               "to":"SUNDAY",
-               "beginTime":"00:00:00.000",
-               "endTime":"23:59:59.999"
+               "from": "MONDAY",
+               "to": "SUNDAY",
+               "beginTime": "00:00:00.000",
+               "endTime": "23:59:59.999"
             }
          ]
       }
    ],
-   "batch_processing":[
+   "batch_processing": [
       {
-         "task_id":"sid-503A048D-6344-446A-8D67-172B164CF8FA",
-         "type":"Sequential",
-         "batch_frequency":1.0,
-         "size_distrib":[
-            {"key": "1", "value": 6},
-            {"key": "3", "value": 35},
-            {"key": "4", "value": 3}
+         "task_id": "sid-503A048D-6344-446A-8D67-172B164CF8FA",
+         "type": "Sequential",
+         "batch_frequency": 1.0,
+         "size_distrib": [
+            {
+               "key": "1",
+               "value": 6
+            },
+            {
+               "key": "3",
+               "value": 35
+            },
+            {
+               "key": "4",
+               "value": 3
+            }
          ],
          "duration_distrib": [
-            {"key": "3", "value": 0.8}
+            {
+               "key": "3",
+               "value": 0.8
+            }
          ],
-         "firing_rules":[
+         "firing_rules": [
             [
                {
-                  "attribute":"size",
-                  "comparison":"=",
-                  "value":3
+                  "attribute": "size",
+                  "comparison": "=",
+                  "value": 3
                }
             ]
          ]
+      }
+   ],
+   "case_attributes": [
+      {
+         "name": "client_type",
+         "type": "discrete",
+         "values": [
+            {
+               "key": "REGULAR",
+               "value": 0.8
+            },
+            {
+               "key": "BUSINESS",
+               "value": 0.2
+            }
+         ]
+      },
+      {
+         "name": "loan_amount",
+         "type": "continuous",
+         "values": {
+            "distribution_name": "fix",
+            "distribution_params": [
+               {
+                  "value": 240
+               },
+               {
+                  "value": 0
+               },
+               {
+                  "value": 1
+               }
+            ]
+         }
       }
    ],
    "event_distribution": {}

--- a/testing_scripts/test_case_attr_log_file.py
+++ b/testing_scripts/test_case_attr_log_file.py
@@ -1,0 +1,99 @@
+import pandas as pd
+import numpy as np
+from test_discovery import assets_path
+from testing_scripts.bimp_diff_sim_tests import run_diff_res_simulation
+from testing_scripts.test_simulation import _setup_and_write_case_attributes
+
+
+def test_case_attr_log_file_correct(assets_path):
+    """
+    Input: run simulation with writting events to the log file.
+            Case attributes' setup defines two additional case_attributes and fixed value REGULAR and 240.
+
+    Output:
+    1) verify the number and naming of the columns
+    2) verify that there are no empty columns
+    3) verify the correctness of the case attributes' values
+    4) verify that resource names are correctly filled for both general task and event
+        (we expect 'No assigned resource' for the event row)
+    """
+
+    model_path = assets_path / 'timer_with_task.bpmn'
+
+    # provide setup for the case attributes generation
+    json_path = assets_path / 'timer_with_task.json'
+    case_attributes = [
+      {
+         "name": "client_type",
+         "type": "discrete",
+         "values": [
+            { "key": "REGULAR", "value": 1 }
+         ]
+      },
+      {
+         "name": "loan_amount",
+         "type": "continuous",
+         "values": {
+            "distribution_name": "fix",
+            "distribution_params": [
+               { "value": 240 },
+               { "value": 0 },
+               { "value": 1 }
+            ]
+         }
+      }
+   ]
+    _setup_and_write_case_attributes(json_path, case_attributes)
+
+    sim_stats = assets_path / 'timer_with_task_stats.csv'
+    sim_logs = assets_path / 'timer_with_task_logs.csv'
+
+    start_string = '2022-06-21 13:22:30.035185+03:00'
+
+    # ====== ACT ======
+    _ = run_diff_res_simulation(start_string,
+                                    5,
+                                    model_path,
+                                    json_path,
+                                    sim_stats,
+                                    sim_logs,
+                                    True)
+
+
+    # ====== ASSERT ======
+    df = pd.read_csv(sim_logs)
+
+    # verify the number and naming of the columns
+    actual_columns = df.columns.values.tolist()
+    expected_columns = ["case_id","activity","enable_time","start_time","end_time",
+        "resource","client_type","loan_amount"]
+    assert actual_columns == expected_columns, \
+        f"Wrong columns' naming. Expected: {expected_columns} but was {actual_columns}"
+    
+    # verify that there are no empty columns 
+    df.replace('', np.nan)                      # replace empty columns with NaN
+    rows_with_nan = df.isna().any(axis=1)       # detect whether there are rows with empty columns 
+    no_nan_values = (rows_with_nan == False).all()
+    assert no_nan_values, \
+        f"The following rows {df[df.isna().any(axis=1)].index.values} have missing columns"
+
+    # verify the correctness of the case attributes' values
+    is_client_type_regular_for_all = (df["client_type"] == "REGULAR").all()
+    assert is_client_type_regular_for_all, \
+        f"Expected value for client_type: REGULAR"
+
+    is_loan_amount_eq_to_expected = (df["loan_amount"] == 240).all()
+    assert is_loan_amount_eq_to_expected, \
+        f"Expected value for loan_amount column: 240"
+
+    # verify that resource names are correctly filled for both general task and event
+    _verify_resource_name(df, "Task 1", "Default resource-000001")
+    _verify_resource_name(df, "15m", "No assigned resource")
+
+
+def _verify_resource_name(df, activity_name, expected_resource_name):
+    filtered_rows = df[df["activity"] == activity_name]
+    assert filtered_rows.shape[0] == 5          # because we simulate 5 process cases
+    is_task_resource_correct = (filtered_rows["resource"] == expected_resource_name).all()
+    assert is_task_resource_correct, \
+        f"Expected value for task '{activity_name}' resource field: {expected_resource_name}"

--- a/testing_scripts/test_case_attr_log_file.py
+++ b/testing_scripts/test_case_attr_log_file.py
@@ -4,96 +4,145 @@ from test_discovery import assets_path
 from testing_scripts.bimp_diff_sim_tests import run_diff_res_simulation
 from testing_scripts.test_simulation import _setup_and_write_case_attributes
 
+basic_columns = [
+    "case_id",
+    "activity",
+    "enable_time",
+    "start_time",
+    "end_time",
+    "resource",
+]
 
-def test_case_attr_log_file_correct(assets_path):
+def test_present_case_attr_correct_output(assets_path):
     """
     Input: run simulation with writting events to the log file.
             Case attributes' setup defines two additional case_attributes and fixed value REGULAR and 240.
 
     Output:
-    1) verify the number and naming of the columns
+    1) verify the number&naming&order of the columns
     2) verify that there are no empty columns
     3) verify the correctness of the case attributes' values
     4) verify that resource names are correctly filled for both general task and event
         (we expect 'No assigned resource' for the event row)
     """
 
-    model_path = assets_path / 'timer_with_task.bpmn'
+    model_path = assets_path / "timer_with_task.bpmn"
 
     # provide setup for the case attributes generation
-    json_path = assets_path / 'timer_with_task.json'
+    json_path = assets_path / "timer_with_task.json"
     case_attributes = [
-      {
-         "name": "client_type",
-         "type": "discrete",
-         "values": [
-            { "key": "REGULAR", "value": 1 }
-         ]
-      },
-      {
-         "name": "loan_amount",
-         "type": "continuous",
-         "values": {
-            "distribution_name": "fix",
-            "distribution_params": [
-               { "value": 240 },
-               { "value": 0 },
-               { "value": 1 }
-            ]
-         }
-      }
-   ]
+        {
+            "name": "client_type",
+            "type": "discrete",
+            "values": [{"key": "REGULAR", "value": 1}],
+        },
+        {
+            "name": "loan_amount",
+            "type": "continuous",
+            "values": {
+                "distribution_name": "fix",
+                "distribution_params": [{"value": 240}, {"value": 0}, {"value": 1}],
+            },
+        },
+    ]
     _setup_and_write_case_attributes(json_path, case_attributes)
 
-    sim_stats = assets_path / 'timer_with_task_stats.csv'
-    sim_logs = assets_path / 'timer_with_task_logs.csv'
+    sim_stats = assets_path / "timer_with_task_stats.csv"
+    sim_logs = assets_path / "timer_with_task_logs.csv"
 
-    start_string = '2022-06-21 13:22:30.035185+03:00'
+    start_string = "2022-06-21 13:22:30.035185+03:00"
 
     # ====== ACT ======
-    _ = run_diff_res_simulation(start_string,
-                                    5,
-                                    model_path,
-                                    json_path,
-                                    sim_stats,
-                                    sim_logs,
-                                    True)
-
+    _ = run_diff_res_simulation(
+        start_string, 5, model_path, json_path, sim_stats, sim_logs, True
+    )
 
     # ====== ASSERT ======
     df = pd.read_csv(sim_logs)
 
     # verify the number and naming of the columns
     actual_columns = df.columns.values.tolist()
-    expected_columns = ["case_id","activity","enable_time","start_time","end_time",
-        "resource","client_type","loan_amount"]
-    assert actual_columns == expected_columns, \
-        f"Wrong columns' naming. Expected: {expected_columns} but was {actual_columns}"
-    
-    # verify that there are no empty columns 
-    df.replace('', np.nan)                      # replace empty columns with NaN
-    rows_with_nan = df.isna().any(axis=1)       # detect whether there are rows with empty columns 
-    no_nan_values = (rows_with_nan == False).all()
-    assert no_nan_values, \
-        f"The following rows {df[df.isna().any(axis=1)].index.values} have missing columns"
+    case_attr_columns = [
+        "client_type",
+        "loan_amount",
+    ]
+    expected_columns = [*basic_columns, *case_attr_columns]
+    assert (
+        actual_columns == expected_columns
+    ), f"Wrong columns' naming. Expected: {expected_columns} but was {actual_columns}"
+
+    # verify that there are no empty columns
+    _verify_no_missed_values(df)
 
     # verify the correctness of the case attributes' values
     is_client_type_regular_for_all = (df["client_type"] == "REGULAR").all()
-    assert is_client_type_regular_for_all, \
-        f"Expected value for client_type: REGULAR"
+    assert is_client_type_regular_for_all, f"Expected value for client_type: REGULAR"
 
     is_loan_amount_eq_to_expected = (df["loan_amount"] == 240).all()
-    assert is_loan_amount_eq_to_expected, \
-        f"Expected value for loan_amount column: 240"
+    assert is_loan_amount_eq_to_expected, f"Expected value for loan_amount column: 240"
 
     # verify that resource names are correctly filled for both general task and event
     _verify_resource_name(df, "Task 1", "Default resource-000001")
     _verify_resource_name(df, "15m", "No assigned resource")
 
 
+def test_no_case_attr_setup_correct_output(assets_path):
+    """
+    Input: run simulation with writting events to the log file.
+            Case attributes' setup is empty so no additional case attributes are added to the log file. 
+
+    Output:
+    1) verify the number&naming&order of the columns (only basic columns are present)
+    2) verify that there are no empty columns
+    """
+
+    model_path = assets_path / "timer_with_task.bpmn"
+
+    # provide setup for the case attributes generation
+    json_path = assets_path / "timer_with_task.json"
+    case_attributes = []
+    _setup_and_write_case_attributes(json_path, case_attributes)
+
+    sim_stats = assets_path / "timer_with_task_stats.csv"
+    sim_logs = assets_path / "timer_with_task_logs.csv"
+
+    start_string = "2022-06-21 13:22:30.035185+03:00"
+
+    # ====== ACT ======
+    _ = run_diff_res_simulation(
+        start_string, 5, model_path, json_path, sim_stats, sim_logs, True
+    )
+
+    # ====== ASSERT ======
+    df = pd.read_csv(sim_logs)
+
+    # verify the number and naming of the columns
+    actual_columns = df.columns.values.tolist()
+    assert (
+        actual_columns == basic_columns
+    ), f"Wrong columns' naming. Expected: {basic_columns} but was {actual_columns}"
+
+    # verify that there are no empty columns
+    _verify_no_missed_values(df)
+
+
 def _verify_resource_name(df, activity_name, expected_resource_name):
     filtered_rows = df[df["activity"] == activity_name]
-    assert filtered_rows.shape[0] == 5          # because we simulate 5 process cases
-    is_task_resource_correct = (filtered_rows["resource"] == expected_resource_name).all()
-    assert is_task_resource_correct, \
-        f"Expected value for task '{activity_name}' resource field: {expected_resource_name}"
+    assert filtered_rows.shape[0] == 5  # because we simulate 5 process cases
+    is_task_resource_correct = (
+        filtered_rows["resource"] == expected_resource_name
+    ).all()
+    assert (
+        is_task_resource_correct
+    ), f"Expected value for task '{activity_name}' resource field: {expected_resource_name}"
+
+
+def _verify_no_missed_values(df: pd.DataFrame):
+    df.replace("", np.nan)  # replace empty columns with NaN
+    rows_with_nan = df.isna().any(
+        axis=1
+    )  # detect whether there are rows with empty columns
+    no_nan_values = (rows_with_nan == False).all()
+    assert (
+        no_nan_values
+    ), f"The following rows {df[df.isna().any(axis=1)].index.values} have missing columns"

--- a/testing_scripts/test_is_enabled.py
+++ b/testing_scripts/test_is_enabled.py
@@ -20,14 +20,14 @@ def test_or_gateway_one_token_before_or_true(assets_path):
     bpmn_path = assets_path / 'test_and_or.bpmn'
     json_path = assets_path / 'test_or_xor_follow.json'
     
-    _, _, element_probability, task_resource, _, event_distribution, batch_processing \
+    _, _, element_probability, task_resource, _, event_distribution, batch_processing, _ \
         = parse_json_sim_parameters(json_path)
 
     bpmn_graph = parse_simulation_model(bpmn_path)
     bpmn_graph.set_additional_fields_from_json(element_probability, task_resource, 
         event_distribution, batch_processing)
     
-    sim_setup = SimDiffSetup(bpmn_path, json_path, False)
+    sim_setup = SimDiffSetup(bpmn_path, json_path, False, 1)
     sim_setup.set_starting_datetime(pytz.utc.localize(datetime.datetime.now()))
     p_state = sim_setup.initial_state()
 
@@ -56,14 +56,14 @@ def test_or_gateway_both_tokens_before_or_true(assets_path):
     bpmn_path = assets_path / 'test_and_or.bpmn'
     json_path = assets_path / 'test_or_xor_follow.json'
     
-    _, _, element_probability, task_resource, _, event_distribution, batch_processing \
+    _, _, element_probability, task_resource, _, event_distribution, batch_processing, _ \
         = parse_json_sim_parameters(json_path)
 
     bpmn_graph = parse_simulation_model(bpmn_path)
     bpmn_graph.set_additional_fields_from_json(element_probability, task_resource,
         event_distribution, batch_processing)
     
-    sim_setup = SimDiffSetup(bpmn_path, json_path, False)
+    sim_setup = SimDiffSetup(bpmn_path, json_path, False, 1)
     sim_setup.set_starting_datetime(pytz.utc.localize(datetime.datetime.now()))
     p_state = sim_setup.initial_state()
 
@@ -96,14 +96,14 @@ def test_or_gateway_one_token_before_xor_false(assets_path):
     bpmn_path = assets_path / 'test_and_or.bpmn'
     json_path = assets_path / 'test_or_xor_follow.json'
     
-    _, _, element_probability, task_resource, _, event_distribution, batch_processing \
+    _, _, element_probability, task_resource, _, event_distribution, batch_processing, _ \
         = parse_json_sim_parameters(json_path)
 
     bpmn_graph = parse_simulation_model(bpmn_path)
     bpmn_graph.set_additional_fields_from_json(element_probability, task_resource,
         event_distribution, batch_processing)
     
-    sim_setup = SimDiffSetup(bpmn_path, json_path, False)
+    sim_setup = SimDiffSetup(bpmn_path, json_path, False, 1)
     sim_setup.set_starting_datetime(pytz.utc.localize(datetime.datetime.now()))
     p_state = sim_setup.initial_state()
 

--- a/testing_scripts/test_simulation.py
+++ b/testing_scripts/test_simulation.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pytest
 import pandas as pd
@@ -43,7 +44,10 @@ def test_timer_event_correct_duration_in_sim_logs(assets_path):
     # ====== ARRANGE ======
 
     model_path = assets_path / 'timer_with_task.bpmn'
+
     json_path = assets_path / 'timer_with_task.json'
+    _setup_and_write_case_attributes(json_path, [])
+
     sim_stats = assets_path / 'timer_with_task_stats.csv'
     sim_logs = assets_path / 'timer_with_task_logs.csv'
 
@@ -96,7 +100,10 @@ def test_timer_event_no_events_in_logs(assets_path):
     # ====== ARRANGE ======
 
     model_path = assets_path / 'timer_with_task.bpmn'
+
     json_path = assets_path / 'timer_with_task.json'
+    _setup_and_write_case_attributes(json_path, [])
+
     sim_stats = assets_path / 'timer_with_task_stats.csv'
     sim_logs = assets_path / 'timer_with_task_logs.csv'
 
@@ -227,3 +234,13 @@ def _verify_activity_count_and_duration(activities, count, expected_activity_tim
     for diff in end_start_diff_for_task:
         assert diff == expected_activity_timedelta, \
             f"The duration of the activity does not equal to {expected_activity_timedelta}"
+
+
+def _setup_and_write_case_attributes(json_path, case_attributes):
+    with open(json_path, "r") as f:
+        json_dict = json.load(f)
+
+    json_dict["case_attributes"] = case_attributes
+
+    with open(json_path, "w+") as json_file:
+        json.dump(json_dict, json_file)

--- a/testing_scripts/test_update_state.py
+++ b/testing_scripts/test_update_state.py
@@ -19,14 +19,14 @@ def test_not_enabled_event_empty_tasks(assets_path):
     bpmn_path = assets_path / 'test_and_or.bpmn'
     json_path = assets_path / 'test_or_xor_follow.json'
     
-    _, _, element_probability, task_resource, _, event_distribution, batch_processing \
+    _, _, element_probability, task_resource, _, event_distribution, batch_processing, _ \
         = parse_json_sim_parameters(json_path)
 
     bpmn_graph = parse_simulation_model(bpmn_path)
     bpmn_graph.set_additional_fields_from_json(element_probability, task_resource,
         event_distribution, batch_processing)
     
-    sim_setup = SimDiffSetup(bpmn_path, json_path, False)
+    sim_setup = SimDiffSetup(bpmn_path, json_path, False, 1)
     sim_setup.set_starting_datetime(pytz.utc.localize(datetime.datetime.now()))
     p_case = 0
     p_state = sim_setup.initial_state()
@@ -66,14 +66,14 @@ def test_enabled_first_task_enables_next_one(assets_path):
     bpmn_path = assets_path / 'test_and_or.bpmn'
     json_path = assets_path / 'test_or_xor_follow.json'
     
-    _, _, element_probability, task_resource, _, event_distribution, batch_processing \
+    _, _, element_probability, task_resource, _, event_distribution, batch_processing, _ \
         = parse_json_sim_parameters(json_path)
 
     bpmn_graph = parse_simulation_model(bpmn_path)
     bpmn_graph.set_additional_fields_from_json(element_probability, task_resource,
         event_distribution, batch_processing)
     
-    sim_setup = SimDiffSetup(bpmn_path, json_path, False)
+    sim_setup = SimDiffSetup(bpmn_path, json_path, False, 1)
     sim_setup.set_starting_datetime(pytz.utc.localize(datetime.datetime.now()))
     p_case = 0
     p_state = sim_setup.initial_state()
@@ -117,14 +117,14 @@ def test_enabled_first_task_token_wait_at_the_or_join(assets_path):
     bpmn_path = assets_path / 'test_and_or.bpmn'
     json_path = assets_path / 'test_or_not_xor_follow.json'
     
-    _, _, element_probability, task_resource, _, event_distribution, batch_processing \
+    _, _, element_probability, task_resource, _, event_distribution, batch_processing, _ \
         = parse_json_sim_parameters(json_path)
 
     bpmn_graph = parse_simulation_model(bpmn_path)
     bpmn_graph.set_additional_fields_from_json(element_probability, task_resource,
         event_distribution, batch_processing)
     
-    sim_setup = SimDiffSetup(bpmn_path, json_path, False)
+    sim_setup = SimDiffSetup(bpmn_path, json_path, False, 1)
     sim_setup.set_starting_datetime(pytz.utc.localize(datetime.datetime.now()))
     p_case = 0
     p_state = sim_setup.initial_state()
@@ -265,14 +265,14 @@ def test_update_state_event_gateway_event_happened(
 
     _setup_sim_scenario_file(json_path, event_distr_array)
     
-    _, _, element_probability, task_resource, _, event_distribution, batch_processing \
+    _, _, element_probability, task_resource, _, event_distribution, batch_processing, _ \
         = parse_json_sim_parameters(json_path)
 
     bpmn_graph = parse_simulation_model(bpmn_path)
     bpmn_graph.set_additional_fields_from_json(element_probability, task_resource,
         event_distribution, batch_processing)
     
-    sim_setup = SimDiffSetup(bpmn_path, json_path, False)
+    sim_setup = SimDiffSetup(bpmn_path, json_path, False, 1)
     sim_setup.set_starting_datetime(pytz.utc.localize(datetime.datetime.now()))
     p_case = 0
     p_state = sim_setup.initial_state()
@@ -320,14 +320,14 @@ def test_update_state_terminate_event(assets_path):
     bpmn_path = assets_path / 'stock_replenishment.bpmn'
     json_path = assets_path / 'stock_replenishment_logs.json'
     
-    _, _, element_probability, task_resource, _, event_distribution, batch_processing \
+    _, _, element_probability, task_resource, _, event_distribution, batch_processing, _ \
         = parse_json_sim_parameters(json_path)
 
     bpmn_graph = parse_simulation_model(bpmn_path)
     bpmn_graph.set_additional_fields_from_json(element_probability, task_resource,
         event_distribution, batch_processing)
     
-    sim_setup = SimDiffSetup(bpmn_path, json_path, False)
+    sim_setup = SimDiffSetup(bpmn_path, json_path, False, 1)
     sim_setup.set_starting_datetime(pytz.utc.localize(datetime.datetime.now()))
     p_case = 0
     p_state = sim_setup.initial_state()


### PR DESCRIPTION
Introduced the case attributes for two parts of the `Prosimos`

1. Adjusting the simulation scenario (setup of the `JSON`). Now, there is an additional property `case_attributes` that specifies the setup for the case attributes' generation. Parsing of this part was added.
2. The result simulated log contains the case attributes specified in the simulation scenario. The case attributes are duplicated for every task/event specified in the log file for the same process case (identified by `case_id`).

The functionality was covered with the test cases:

- verifying that an empty setup of `case_attributes` results in the basic number of columns (same as before introducing case attributes).
- verifying that setup with `case_attributes` of both types (`discrete` and `continuous`) results in additional columns calculated in the simulated log. 